### PR TITLE
fix NumPy trapz removal in dashboard robustness

### DIFF
--- a/src/testAUC/utils.py
+++ b/src/testAUC/utils.py
@@ -56,7 +56,7 @@ class Perturbation(ABC):
         # auc_gains = [self._get_pertrubed_socre_auc(y, ŷ, σ) for σ in self.σs]
         auc_gains = np.array(auc_gains)
 
-        perturbation_auc = np.trapz(auc_gains) / len(auc_gains)
+        perturbation_auc = np.trapezoid(auc_gains) / len(auc_gains)
         return auc_gains, perturbation_auc
 
 class NoiseRobustness(Perturbation):


### PR DESCRIPTION
Have made a quick automatic fix to the issue and tested with the workflow specified in the README.

## Summary
- Replace `np.trapz` with `np.trapezoid` in perturbation AUC computation used by dashboard noise robustness
- Fixes `AttributeError: module 'numpy' has no attribute 'trapz'` on NumPy 2.x (closes #2)

## Test plan
- [x] Run `python -m compileall src`
- [x] Run `MPLBACKEND=Agg uv run python -c "from testAUC import faux_normal_predictions, dashboard; y_true_val,y_score_val=faux_normal_predictions(neg_mu=0.3,pos_mu=0.8,seed=2023); y_true_tst,y_score_tst=faux_normal_predictions(std=0.5,neg_mu=0.4,pos_mu=0.9,seed=2023); dashboard(y_true_val,y_score_val,y_true_tst,y_score_tst); print('dashboard_ok')"`
- [x] Confirm NumPy API: `uv run python -c "import numpy as np; print(np.__version__, hasattr(np, 'trapezoid'), hasattr(np, 'trapz'))"` → `2.4.4 True False`